### PR TITLE
refactor crypto helper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea
+/vendor

--- a/README.md
+++ b/README.md
@@ -1,1 +1,53 @@
-# cryhel
+# Qeek.dev crypto helper
+
+> crypto helper to handle data encrypt and decrypt
+
+## Environment
+
+- [x] go 1.7.1 docker image: qeekdev/golang:1.7.1-ubuntu build from : tools/docker/golang
+- [x] glide 0.12.1
+
+## Installation
+
+### clone repo and install go packages
+
+```sh
+# make github.com/qeek-dev if does not exist and switch to
+$ cd $GOPATH/src/github.com/qeek-dev
+
+# clone repo
+$ git clone git@github.com:qeek-dev/cryhel.git
+
+$ cd cryhel
+
+# install requirement go packages
+$ glide update
+$ glide i
+```
+
+### Testing
+
+```sh
+$ go test
+OK: 8 passed
+PASS
+ok      github.com/qeek-dev/cryhel      0.010s
+```
+
+## Usage
+
+```go
+// new crypto helper
+c, err = cryhel.NewCrypto("AES256Key-32Characters1234567890")
+
+// encrypt
+enc, err := c.Encrypt.Msg("string your want to encrypt").Do()
+enc, err := c.Encrypt.QueryEscapeMsg("string your want to encrypt").Do()
+
+// decrypt
+// Out(&out): json.Unmarshal to struct, dependency on what struct you encrypt to
+dec, err := c.Decrypt.Msg("encrypt string").Do()
+dec, err := c.Decrypt.Msg("encrypt string").Out(&out)
+dec, err := c.Decrypt.QueryEscapeMsg("encryptBase64String").Do()
+dec, err := c.Decrypt.QueryEscapeMsg("encryptBase64String").Out(&out)
+```

--- a/cryhel.go
+++ b/cryhel.go
@@ -1,0 +1,244 @@
+package cryhel
+
+import (
+	"bytes"
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/url"
+	"reflect"
+)
+
+// any is purely semantic
+type any interface{}
+
+// Pointer is purely semantic
+type pointer interface{}
+
+func isPointer(value any) bool {
+	if reflect.ValueOf(value).Kind() != reflect.Ptr {
+		return false
+	}
+	return true
+}
+
+// encrypt general func
+func (c *Crypto) encrypt(msg string) ([]byte, error) {
+	plaintext := ZeroPadding([]byte(msg))
+
+	if len(plaintext)%aes.BlockSize != 0 {
+		return nil, errors.New("plaintext is not a multiple of the block size")
+	}
+
+	ciphertext := make([]byte, aes.BlockSize+len(plaintext))
+	iv := ciphertext[:aes.BlockSize]
+	if _, err := io.ReadFull(rand.Reader, iv); err != nil {
+		return nil, errors.New(err.Error())
+	}
+
+	mode := cipher.NewCBCEncrypter(c.block, iv)
+	mode.CryptBlocks(ciphertext[aes.BlockSize:], plaintext)
+
+	return ciphertext, nil
+}
+
+// decrypt general func
+func (c *Crypto) decrypt(ciphertext []byte) ([]byte, error) {
+	blockMode := cipher.NewCBCDecrypter(c.block, c.bkey[:c.block.BlockSize()])
+	if len(ciphertext) < aes.BlockSize {
+		return nil, errors.New("ciphertext too short")
+	}
+	if len(ciphertext)%aes.BlockSize != 0 {
+		return nil, errors.New("ciphertext is not a multiple of the block size")
+	}
+
+	planeText := make([]byte, len(ciphertext))
+	blockMode.CryptBlocks(planeText, ciphertext)
+
+	planeText = ZeroUnPadding(planeText[aes.BlockSize:])
+	return planeText, nil
+}
+
+func ZeroPadding(in []byte) []byte {
+	padding := aes.BlockSize - (len(in) % aes.BlockSize)
+	padtext := bytes.Repeat([]byte{0}, padding)
+	return append(in, padtext...)
+}
+
+func ZeroUnPadding(origData []byte) []byte {
+	return bytes.TrimFunc(origData,
+		func(r rune) bool {
+			return r == rune(0)
+		})
+}
+
+// Crypto struct
+type Crypto struct {
+	block cipher.Block
+	bkey  []byte
+
+	Encrypt *EncryptService
+	Decrypt *DecryptService
+}
+
+func NewCrypto(secretkey string) (c *Crypto, err error) {
+	if secretkey == "" {
+		err = errors.New("secret key empty")
+		return
+	}
+
+	c = &Crypto{}
+	c.bkey = []byte(secretkey)
+	c.block, err = aes.NewCipher(c.bkey)
+	c.Encrypt = NewEncryptService(c)
+	c.Decrypt = NewDecryptService(c)
+	if err != nil {
+		return
+	}
+	return
+}
+
+//-----------------------------------------------------------------------------
+// EncryptService
+type EncryptService struct {
+	s *Crypto
+}
+
+func NewEncryptService(s *Crypto) *EncryptService {
+	rs := &EncryptService{s: s}
+	return rs
+}
+
+// method  "Crypto.Encrypt.Msg"
+type EncryptMsgCall struct {
+	s *Crypto
+	m string
+}
+
+func (r *EncryptService) Msg(msg string) *EncryptMsgCall {
+	c := &EncryptMsgCall{s: r.s, m: msg}
+	return c
+}
+
+func (r *EncryptMsgCall) Do() (string, error) {
+	if ciphertext, err := r.s.encrypt(r.m); err != nil {
+		return "", err
+	} else {
+		return base64.StdEncoding.EncodeToString(ciphertext), nil
+	}
+}
+
+// method  "Crypto.Encrypt.QueryEscapeMsg"
+type EncryptQueryEscapeMsgCall struct {
+	s *Crypto
+	m string
+}
+
+func (r *EncryptService) QueryEscapeMsg(msg string) *EncryptQueryEscapeMsgCall {
+	c := &EncryptQueryEscapeMsgCall{s: r.s, m: msg}
+	return c
+}
+
+func (r *EncryptQueryEscapeMsgCall) Do() (string, error) {
+	if ciphertext, err := r.s.encrypt(r.m); err != nil {
+		return "", err
+	} else {
+		base64EncodeString := url.QueryEscape(base64.StdEncoding.EncodeToString(ciphertext))
+
+		return base64EncodeString, nil
+	}
+}
+
+//-----------------------------------------------------------------------------
+// DecryptService
+type DecryptService struct {
+	s *Crypto
+}
+
+func NewDecryptService(s *Crypto) *DecryptService {
+	rs := &DecryptService{s: s}
+	return rs
+}
+
+// method  "Crypto.Decrypt.Msg"
+type DecryptMsgCall struct {
+	s *Crypto
+	m string
+}
+
+func (r *DecryptService) Msg(msg string) *DecryptMsgCall {
+	c := &DecryptMsgCall{s: r.s, m: msg}
+	return c
+}
+
+func (r *DecryptMsgCall) Do() (string, error) {
+	ciphertext, _ := base64.StdEncoding.DecodeString(r.m) // decrypt base64
+	buf, err := r.s.decrypt(ciphertext)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func (r *DecryptMsgCall) Out(out pointer) error {
+	if !isPointer(out) {
+		return errors.New(fmt.Sprintf("Value '%s' is not a pointer", out))
+	}
+
+	ciphertext, _ := base64.StdEncoding.DecodeString(r.m) // decrypt base64
+	buf, err := r.s.decrypt(ciphertext)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(buf, out); err != nil {
+		return err
+	} else {
+		return nil
+	}
+}
+
+// method  "Crypto.Decrypt.QueryEscapeMsg"
+type DecryptQueryEscapeMsgCall struct {
+	s *Crypto
+	m string
+}
+
+func (r *DecryptService) QueryEscapeMsg(msg string) *DecryptQueryEscapeMsgCall {
+	c := &DecryptQueryEscapeMsgCall{s: r.s, m: msg}
+	return c
+}
+
+func (r *DecryptQueryEscapeMsgCall) Do() (string, error) {
+	base64Encode, _ := url.QueryUnescape(r.m)                      // url unescape
+	ciphertext, _ := base64.StdEncoding.DecodeString(base64Encode) // decrypt base64
+	buf, err := r.s.decrypt(ciphertext)
+	if err != nil {
+		return "", err
+	}
+	return string(buf), nil
+}
+
+func (r *DecryptQueryEscapeMsgCall) Out(out pointer) error {
+	if !isPointer(out) {
+		return errors.New(fmt.Sprintf("Value '%s' is not a pointer", out))
+	}
+
+	base64Encode, _ := url.QueryUnescape(r.m)                      // url unescape
+	ciphertext, _ := base64.StdEncoding.DecodeString(base64Encode) // decrypt base64
+	buf, err := r.s.decrypt(ciphertext)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(buf, out); err != nil {
+		return err
+	} else {
+		return nil
+	}
+}
+
+//-----------------------------------------------------------------------------

--- a/cryhel_test.go
+++ b/cryhel_test.go
@@ -1,0 +1,136 @@
+package cryhel_test
+
+import (
+	"testing"
+
+	. "gopkg.in/check.v1"
+
+	"github.com/qeek-dev/cryhel"
+)
+
+func Test(t *testing.T) { TestingT(t) }
+
+type MySuite struct {
+	c *cryhel.Crypto
+}
+
+func (s *MySuite) SetUpTest(c *C) {
+	s.c, _ = cryhel.NewCrypto("AES256Key-32Characters1234567890")
+}
+
+var _ = Suite(&MySuite{})
+
+func (s *MySuite) Test_Encrypt(chk *C) {
+	sourceString := "1/fFAGRNJru1FTz70BzhT3Zg"
+	if encryptString, err := s.c.Encrypt.Msg(sourceString).Do(); err != nil {
+		chk.Error(err.Error())
+	} else {
+		chk.Logf("encrypt base64 encode string: %q", encryptString)
+	}
+}
+
+func (s *MySuite) Test_Decrypt(chk *C) {
+	encryptString := "cLcbvk4rpVRTj1kvu5pOi7ktZiCezDWcm8VR1f+XpP12eie0/cI6lagGcWXRMt8a"
+	if creds, err := s.c.Decrypt.Msg(encryptString).Do(); err != nil {
+		chk.Error(err.Error())
+	} else {
+		if creds != "1/fFAGRNJru1FTz70BzhT3Zg" {
+			chk.Errorf("got access_token %q expected %q", creds, "1/fFAGRNJru1FTz70BzhT3Zg")
+		} else {
+			chk.Logf("decrypt string: %q", creds)
+		}
+	}
+}
+
+func (s *MySuite) Test_Encrypt_QueryEscapeMsg(chk *C) {
+	sourceString := "1/fFAGRNJru1FTz70BzhT3Zg"
+	if encryptString, err := s.c.Encrypt.QueryEscapeMsg(sourceString).Do(); err != nil {
+		chk.Error(err.Error())
+	} else {
+		chk.Logf("encrypt base64 encode string: %q", encryptString)
+	}
+}
+
+func (s *MySuite) Test_Decrypt_QueryEscapeMsg(chk *C) {
+	encryptBase64String := "%2BDldN9TgkkWuH5V68jOVB9uNVXMpGam5Yixh0fRCr3qHVZG7Jn1JNZwhGVaPw%2B3z"
+
+	if decryptString, err := s.c.Decrypt.QueryEscapeMsg(encryptBase64String).Do(); err != nil {
+		chk.Error(err.Error())
+	} else {
+		if decryptString != "1/fFAGRNJru1FTz70BzhT3Zg" {
+			chk.Errorf("got access_token %q expected %q", decryptString, "1/fFAGRNJru1FTz70BzhT3Zg")
+		} else {
+			chk.Logf("decrypt base64 encode string: %q", decryptString)
+		}
+	}
+}
+
+func (s *MySuite) Test_Encrypt_Decrypt_Msg(chk *C) {
+	sourceString := `{"user":"admin","type":"2","streamKey":"live?token=b31d0e541427f52debea0f6d0ca368454f5323b384571b466f5894a3e100dd5d94cfb4a49ded"}`
+
+	if encryptBase64String, err := s.c.Encrypt.Msg(sourceString).Do(); err != nil {
+		chk.Error(err.Error())
+	} else {
+		if decryptString, err := s.c.Decrypt.Msg(encryptBase64String).Do(); err != nil {
+			chk.Errorf("got descrypt %q expected %q", decryptString, sourceString)
+		} else {
+			chk.Logf("decrypt base64 encode string: %q", decryptString)
+		}
+	}
+}
+
+func (s *MySuite) Test_Encrypt_Decrypt_QueryEscapeMsg(chk *C) {
+	sourceString := `{"user":"admin","type":"2","streamKey":"live?token=b31d0e541427f52debea0f6d0ca368454f5323b384571b466f5894a3e100dd5d94cfb4a49ded"}`
+
+	if encryptBase64String, err := s.c.Encrypt.QueryEscapeMsg(sourceString).Do(); err != nil {
+		chk.Error(err.Error())
+	} else {
+		if decryptString, err := s.c.Decrypt.QueryEscapeMsg(encryptBase64String).Do(); err != nil {
+			chk.Errorf("got descrypt %q expected %q", decryptString, sourceString)
+		} else {
+			chk.Logf("decrypt base64 encode string: %q", decryptString)
+		}
+	}
+}
+
+func (s *MySuite) Test_Encrypt_Decrypt_Out_Msg(chk *C) {
+	type Info struct {
+		User      string `json:"user"`
+		Type      string `json:"type"`
+		StreamKey string `json:"streamKey"`
+	}
+
+	sourceString := `{"user":"admin","type":"2","streamKey":"live?token=b31d0e541427f52debea0f6d0ca368454f5323b384571b466f5894a3e100dd5d94cfb4a49ded"}`
+
+	if encryptBase64String, err := s.c.Encrypt.Msg(sourceString).Do(); err != nil {
+		chk.Error(err.Error())
+	} else {
+		var b Info
+		if err := s.c.Decrypt.Msg(encryptBase64String).Out(&b); err != nil {
+			chk.Errorf("got descrypt %v expected %q", b, sourceString)
+		} else {
+			chk.Logf("decrypt base64 encode struct: %v", b)
+		}
+	}
+}
+
+func (s *MySuite) Test_Encrypt_Decrypt_Out_QueryEscapeMsg(chk *C) {
+	type Info struct {
+		User      string `json:"user"`
+		Type      string `json:"type"`
+		StreamKey string `json:"streamKey"`
+	}
+
+	sourceString := `{"user":"admin","type":"2","streamKey":"live?token=b31d0e541427f52debea0f6d0ca368454f5323b384571b466f5894a3e100dd5d94cfb4a49ded"}`
+
+	if encryptBase64String, err := s.c.Encrypt.QueryEscapeMsg(sourceString).Do(); err != nil {
+		chk.Error(err.Error())
+	} else {
+		var b Info
+		if err := s.c.Decrypt.QueryEscapeMsg(encryptBase64String).Out(&b); err != nil {
+			chk.Errorf("got descrypt %v expected %q", b, sourceString)
+		} else {
+			chk.Logf("decrypt base64 encode struct: %v", b)
+		}
+	}
+}

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,6 @@
+hash: 1d60b400b2f5031b90913151a69e82bc081af8b8c94d17edb1a624d6e9252861
+updated: 2017-02-19T13:28:47.931396545+08:00
+imports: []
+testImports:
+- name: gopkg.in/check.v1
+  version: 20d25e2804050c1cd24a7eea1e7a6447dd0e74ec

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,4 +1,4 @@
-package: github.com/qeek-dev/ccstalk
+package: github.com/qeek-dev/cryhel
 import: []
 testImport:
 - package: gopkg.in/check.v1

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,4 @@
+package: github.com/qeek-dev/ccstalk
+import: []
+testImport:
+- package: gopkg.in/check.v1


### PR DESCRIPTION
重構 crypto helper 基礎元件，並 open source，專案砍掉重練拿掉敏感 app id

```go
// new crypto helper
c, err = cryhel.NewCrypto("AES256Key-32Characters1234567890")

// encrypt
enc, err := c.Encrypt.Msg("string your want to encrypt").Do()
enc, err := c.Encrypt.QueryEscapeMsg("string your want to encrypt").Do()

// decrypt
// Out(&out): json.Unmarshal to struct, dependency on what struct you encrypt to
dec, err := c.Decrypt.Msg("encrypt string").Do()
dec, err := c.Decrypt.Msg("encrypt string").Out(&out)
dec, err := c.Decrypt.QueryEscapeMsg("encryptBase64String").Do()
dec, err := c.Decrypt.QueryEscapeMsg("encryptBase64String").Out(&out)
```