### PR TITLE
add decrypt/encrypt custom base64 encoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ $ glide i
 
 ```sh
 $ go test
-OK: 8 passed
+OK: 7 passed
 PASS
 ok      github.com/qeek-dev/cryhel      0.010s
 ```
@@ -40,14 +40,24 @@ ok      github.com/qeek-dev/cryhel      0.010s
 // new crypto helper
 c, err = cryhel.NewCrypto("AES256Key-32Characters1234567890")
 
-// encrypt
+// encrypt (default base64 StdEncoding)
 enc, err := c.Encrypt.Msg("string your want to encrypt").Do()
-enc, err := c.Encrypt.QueryEscapeMsg("string your want to encrypt").Do()
 
-// decrypt
-// Out(&out): json.Unmarshal to struct, dependency on what struct you encrypt to
+// encrypt
+// StdEncoding
+// URLEncoding
+// RawStdEncoding
+// RawURLEncoding
+enc, err := c.Encrypt.Msg("string your want to encrypt").Encoding(base64.RawURLEncoding).Do()
+
+// decrypt with default encoding: base64.StdEncoding
 dec, err := c.Decrypt.Msg("encrypt string").Do()
-dec, err := c.Decrypt.Msg("encrypt string").Out(&out)
-dec, err := c.Decrypt.QueryEscapeMsg("encryptBase64String").Do()
-dec, err := c.Decrypt.QueryEscapeMsg("encryptBase64String").Out(&out)
+
+// Out(&out): json.Unmarshal to struct, dependency on what struct you encrypt to
+// decrypt with default encoding: base64.StdEncoding
+dec, err := c.Decrypt.Msg("encrypt string").Do(&out)
+
+// Out(&out): json.Unmarshal to struct, dependency on what struct you encrypt to
+// decrypt with default encoding: base64.RawURLEncoding
+dec, err := c.Decrypt.Msg("encryptBase64String").Encoding(base64.RawURLEncoding).Do()(&out)
 ```

--- a/cryhel_test.go
+++ b/cryhel_test.go
@@ -1,6 +1,7 @@
 package cryhel_test
 
 import (
+	"encoding/base64"
 	"testing"
 
 	. "gopkg.in/check.v1"
@@ -20,7 +21,7 @@ func (s *MySuite) SetUpTest(c *C) {
 
 var _ = Suite(&MySuite{})
 
-func (s *MySuite) Test_Encrypt(chk *C) {
+func (s *MySuite) Test_Encrypt_Base64_StdEncoding(chk *C) {
 	sourceString := "1/fFAGRNJru1FTz70BzhT3Zg"
 	if encryptString, err := s.c.Encrypt.Msg(sourceString).Do(); err != nil {
 		chk.Error(err.Error())
@@ -29,7 +30,7 @@ func (s *MySuite) Test_Encrypt(chk *C) {
 	}
 }
 
-func (s *MySuite) Test_Decrypt(chk *C) {
+func (s *MySuite) Test_Decrypt_Base64_StdEncoding(chk *C) {
 	encryptString := "cLcbvk4rpVRTj1kvu5pOi7ktZiCezDWcm8VR1f+XpP12eie0/cI6lagGcWXRMt8a"
 	if creds, err := s.c.Decrypt.Msg(encryptString).Do(); err != nil {
 		chk.Error(err.Error())
@@ -42,25 +43,36 @@ func (s *MySuite) Test_Decrypt(chk *C) {
 	}
 }
 
-func (s *MySuite) Test_Encrypt_QueryEscapeMsg(chk *C) {
+func (s *MySuite) Test_Encrypt_Base64_RawURLEncoding(chk *C) {
 	sourceString := "1/fFAGRNJru1FTz70BzhT3Zg"
-	if encryptString, err := s.c.Encrypt.QueryEscapeMsg(sourceString).Do(); err != nil {
+	if encryptString, err := s.c.Encrypt.Msg(sourceString).Encoding(base64.RawURLEncoding).Do(); err != nil {
 		chk.Error(err.Error())
 	} else {
 		chk.Logf("encrypt base64 encode string: %q", encryptString)
 	}
 }
 
-func (s *MySuite) Test_Decrypt_QueryEscapeMsg(chk *C) {
-	encryptBase64String := "%2BDldN9TgkkWuH5V68jOVB9uNVXMpGam5Yixh0fRCr3qHVZG7Jn1JNZwhGVaPw%2B3z"
-
-	if decryptString, err := s.c.Decrypt.QueryEscapeMsg(encryptBase64String).Do(); err != nil {
+func (s *MySuite) Test_Decrypt_Base64_RawURLEncoding(chk *C) {
+	encryptString := "yMeF0f/D03Hw2AieRkLejswAO0E36iO/KTph7R8uBKcWdiOC1MgWAqRwqBpVxpK/"
+	if encryptString, err := s.c.Encrypt.Msg(encryptString).Encoding(base64.RawURLEncoding).Do(); err != nil {
 		chk.Error(err.Error())
 	} else {
-		if decryptString != "1/fFAGRNJru1FTz70BzhT3Zg" {
-			chk.Errorf("got access_token %q expected %q", decryptString, "1/fFAGRNJru1FTz70BzhT3Zg")
+		chk.Logf("source string: %q", encryptString)
+	}
+}
+
+func (s *MySuite) Test_Encrypt_Decrypt_Base64_RawURLEncoding(chk *C) {
+	sourceString := "1/fFAGRNJru1FTz70BzhT3Zg"
+	if encryptString, err := s.c.Encrypt.Msg(sourceString).Encoding(base64.RawURLEncoding).Do(); err != nil {
+		chk.Error(err.Error())
+	} else {
+		chk.Logf("encrypt base64 RawURLEncoding string: %q", encryptString)
+
+		decryptString, err := s.c.Decrypt.Msg(encryptString).Encoding(base64.RawURLEncoding).Do()
+		if err != nil {
+			chk.Errorf("got decrypt message %q expected %q", decryptString, "1/fFAGRNJru1FTz70BzhT3Zg")
 		} else {
-			chk.Logf("decrypt base64 encode string: %q", decryptString)
+			chk.Logf("decrypt decrypt message: %q", decryptString)
 		}
 	}
 }
@@ -72,20 +84,6 @@ func (s *MySuite) Test_Encrypt_Decrypt_Msg(chk *C) {
 		chk.Error(err.Error())
 	} else {
 		if decryptString, err := s.c.Decrypt.Msg(encryptBase64String).Do(); err != nil {
-			chk.Errorf("got descrypt %q expected %q", decryptString, sourceString)
-		} else {
-			chk.Logf("decrypt base64 encode string: %q", decryptString)
-		}
-	}
-}
-
-func (s *MySuite) Test_Encrypt_Decrypt_QueryEscapeMsg(chk *C) {
-	sourceString := `{"user":"admin","type":"2","streamKey":"live?token=b31d0e541427f52debea0f6d0ca368454f5323b384571b466f5894a3e100dd5d94cfb4a49ded"}`
-
-	if encryptBase64String, err := s.c.Encrypt.QueryEscapeMsg(sourceString).Do(); err != nil {
-		chk.Error(err.Error())
-	} else {
-		if decryptString, err := s.c.Decrypt.QueryEscapeMsg(encryptBase64String).Do(); err != nil {
 			chk.Errorf("got descrypt %q expected %q", decryptString, sourceString)
 		} else {
 			chk.Logf("decrypt base64 encode string: %q", decryptString)
@@ -107,27 +105,6 @@ func (s *MySuite) Test_Encrypt_Decrypt_Out_Msg(chk *C) {
 	} else {
 		var b Info
 		if err := s.c.Decrypt.Msg(encryptBase64String).Out(&b); err != nil {
-			chk.Errorf("got descrypt %v expected %q", b, sourceString)
-		} else {
-			chk.Logf("decrypt base64 encode struct: %v", b)
-		}
-	}
-}
-
-func (s *MySuite) Test_Encrypt_Decrypt_Out_QueryEscapeMsg(chk *C) {
-	type Info struct {
-		User      string `json:"user"`
-		Type      string `json:"type"`
-		StreamKey string `json:"streamKey"`
-	}
-
-	sourceString := `{"user":"admin","type":"2","streamKey":"live?token=b31d0e541427f52debea0f6d0ca368454f5323b384571b466f5894a3e100dd5d94cfb4a49ded"}`
-
-	if encryptBase64String, err := s.c.Encrypt.QueryEscapeMsg(sourceString).Do(); err != nil {
-		chk.Error(err.Error())
-	} else {
-		var b Info
-		if err := s.c.Decrypt.QueryEscapeMsg(encryptBase64String).Out(&b); err != nil {
 			chk.Errorf("got descrypt %v expected %q", b, sourceString)
 		} else {
 			chk.Logf("decrypt base64 encode struct: %v", b)


### PR DESCRIPTION
Add encrypt decrypt custom base64 encoding

```go
// new crypto helper
c, err = cryhel.NewCrypto("AES256Key-32Characters1234567890")

// encrypt (default base64 StdEncoding)
enc, err := c.Encrypt.Msg("string your want to encrypt").Do()

// encrypt
// StdEncoding
// URLEncoding
// RawStdEncoding
// RawURLEncoding
enc, err := c.Encrypt.Msg("string your want to encrypt").Encoding(base64.RawURLEncoding).Do()

// decrypt with default encoding: base64.StdEncoding
dec, err := c.Decrypt.Msg("encrypt string").Do()

// Out(&out): json.Unmarshal to struct, dependency on what struct you encrypt to
// decrypt with default encoding: base64.StdEncoding
dec, err := c.Decrypt.Msg("encrypt string").Do(&out)

// Out(&out): json.Unmarshal to struct, dependency on what struct you encrypt to
// decrypt with default encoding: base64.RawURLEncoding
dec, err := c.Decrypt.Msg("encryptBase64String").Encoding(base64.RawURLEncoding).Do()(&out)
```